### PR TITLE
duplicate async await functions

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -78,7 +78,7 @@ export default {
       ],
       plugins: [
         '@babel/plugin-syntax-dynamic-import',
-        'babel-plugin-transform-async-to-promises',
+        ["babel-plugin-transform-async-to-promises", { externalHelpers: true }],
         [
           '@babel/plugin-transform-runtime',
           {


### PR DESCRIPTION
https://github.com/rpetrich/babel-plugin-transform-async-to-promises#output-with-externalhelpers-enabled